### PR TITLE
Fix for with_coverage.py

### DIFF
--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -52,7 +52,7 @@ class CoverageReporter(object):
         # Exclude by directory
         excluded.extend(getattr(settings, 'COVERAGE_EXCLUDES_FOLDERS', []))
 
-        return [filename for filename in coverage.data.measured_files()
+        return [filename for filename in coverage._data.measured_files()
                 if not (os.sep + 'migrations' + os.sep) in filename
                 if not (os.sep + 'south_migrations' + os.sep) in filename
                 if any(filename.startswith(location) for location in tested_locations)

--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -59,7 +59,7 @@ class CoverageReporter(object):
                 if not any(filename.startswith(location) for location in excluded)]
 
     def default_coverage_config(self):
-        rcfile = getattr(settings, 'COVERAGE_RCFILE', 'coverage.rc')
+        rcfile = getattr(settings, 'COVERAGE_RCFILE', '.coveragerc')
         if os.path.exists(rcfile):
             return rcfile
         return None


### PR DESCRIPTION
This fixes a crash during coverage report generation with coverage==7.6.1

The coverage data model seems to have changed since this was written: the field is now '_data' rather than 'data'

---

This pull request includes changes to the `django_jenkins` package to improve coverage file handling and directory exclusion logic. The key changes involve updating the method for retrieving measured files and modifying the default coverage configuration file.

Coverage file handling:

* [`django_jenkins/tasks/with_coverage.py`](diffhunk://#diff-10c47526f9e8564528828e305b49d1cdb0ab15af4d9e97dd7100171087f69991L55-R62): Changed the method to retrieve measured files from `coverage.data.measured_files()` to `coverage._data.measured_files()` to access the correct attribute.

Directory exclusion logic:

* [`django_jenkins/tasks/with_coverage.py`](diffhunk://#diff-10c47526f9e8564528828e305b49d1cdb0ab15af4d9e97dd7100171087f69991L55-R62): Updated the default coverage configuration file from `coverage.rc` to `.coveragerc` to align with common conventions.